### PR TITLE
Fix Hyperlinks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@
 
 **Full documentation** is [available at Read The Docs](https://fastapi-keycloak-middleware.readthedocs.io/en/latest/)
 
-This package provides a middleware for [FastAPI](http://fastapi.tiangolo.com>)  that
-simplifies integrating with [Keycloak](http://http://keycloak.org>) for
+This package provides a middleware for [FastAPI](http://fastapi.tiangolo.com)  that
+simplifies integrating with [Keycloak](http://keycloak.org) for
 authentication and authorization. It supports OIDC and supports validating access
 tokens, reading roles and basic authentication. In addition it provides several
 decorators and dependencies to easily integrate into your FastAPI application.
 
 It relies on the [python-keycloak](http://python-keycloak.readthedocs.io) package,
 which is the only dependency outside of the FastAPI ecosystem which would be installed
-anyway. Shoutout to the author of [fastapi-auth-middleware](https://github.com/code-specialist/fastapi-auth-middleware>)
+anyway. Shoutout to the author of [fastapi-auth-middleware](https://github.com/code-specialist/fastapi-auth-middleware)
 which served as inspiration for this package and some of its code.
 
 In the future, I plan to add support for fine grained authorization using Keycloak


### PR DESCRIPTION
The referenced links can’t be reached, since there are typo in the URLs.

![image](https://github.com/waza-ari/fastapi-keycloak-middleware/assets/28670760/623490dd-5f8a-4656-8b51-178bea52411b)

![image](https://github.com/waza-ari/fastapi-keycloak-middleware/assets/28670760/19b3c709-5fee-4fb4-ab65-fc666e1bda68)

![image](https://github.com/waza-ari/fastapi-keycloak-middleware/assets/28670760/db78e09d-cc1b-456d-9f37-b2257a82d40f)
