### PR TITLE
added functionality to set a custom path for the authorization_claim

### DIFF
--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -97,6 +97,35 @@ By default, the :code:`roles` claim will be checked to build the scope. You can 
 
 In this example, the library would extract the scopes from the :code:`permissions` claim.
 
+You can also provide a custom claim path with the :code:`authorization_claim_path` parameter. 
+This is useful if the claim is nested within the payload.
+
+.. code-block:: python
+    :emphasize-lines: 6
+
+    app.add_middleware(
+        KeycloakMiddleware,
+        keycloak_configuration=keycloak_config,
+        get_user=auth_get_user,
+        authorization_method=AuthorizationMethod.CLAIM,
+        authorization_claim_path=["realm_access", "roles"]
+    )
+
+This would extract the scopes from the :code:`roles` claim nested within the :code:`realm_access` claim.
+.. code-block:: json
+    
+    "claimX": "",
+    "realm_access": {
+        "roles": [
+            "supporter",
+            "admin",
+            "user"
+        ]
+    },
+    "claimY": "",
+
+It will prefer the :code:`authorization_claim_path` parameter over the :code:`authorization_claim` parameter if both are provided.
+
 Permission Mapping
 ^^^^^^^^^^^^^^^^^^
 

--- a/fastapi_keycloak_middleware/keycloak_backend.py
+++ b/fastapi_keycloak_middleware/keycloak_backend.py
@@ -166,9 +166,18 @@ class KeycloakBackend(AuthenticationBackend):
             self.keycloak_configuration.authorization_method
             == AuthorizationMethod.CLAIM
         ):
-            if self.keycloak_configuration.authorization_claim not in token_info:
-                raise AuthClaimMissing
-            scope_auth = token_info[self.keycloak_configuration.authorization_claim]
+            #Check if a path to the Claim is provided otherwise use the Claim directly
+            if self.keycloak_configuration.authorization_claim_path:
+                scope_auth = token_info
+                for path in self.keycloak_configuration.authorization_claim_path:
+                    try:
+                        scope_auth = scope_auth[path]
+                    except KeyError:
+                        raise AuthClaimMissing
+            else:
+                if self.keycloak_configuration.authorization_claim not in token_info:
+                    raise AuthClaimMissing
+                scope_auth = token_info[self.keycloak_configuration.authorization_claim]           
 
         # Check if the device authentication claim is present and evaluated to true
         # If so, the rest (mapping claims, user mapper, authorization) is skipped

--- a/fastapi_keycloak_middleware/keycloak_backend.py
+++ b/fastapi_keycloak_middleware/keycloak_backend.py
@@ -166,7 +166,7 @@ class KeycloakBackend(AuthenticationBackend):
             self.keycloak_configuration.authorization_method
             == AuthorizationMethod.CLAIM
         ):
-            #Check if a path to the Claim is provided otherwise use the Claim directly
+            # Check if a path to the Claim is provided otherwise use the Claim directly
             if self.keycloak_configuration.authorization_claim_path:
                 scope_auth = token_info
                 for path in self.keycloak_configuration.authorization_claim_path:
@@ -177,7 +177,7 @@ class KeycloakBackend(AuthenticationBackend):
             else:
                 if self.keycloak_configuration.authorization_claim not in token_info:
                     raise AuthClaimMissing
-                scope_auth = token_info[self.keycloak_configuration.authorization_claim]           
+                scope_auth = token_info[self.keycloak_configuration.authorization_claim]
 
         # Check if the device authentication claim is present and evaluated to true
         # If so, the rest (mapping claims, user mapper, authorization) is skipped

--- a/fastapi_keycloak_middleware/schemas/keycloak_configuration.py
+++ b/fastapi_keycloak_middleware/schemas/keycloak_configuration.py
@@ -40,6 +40,9 @@ class KeycloakConfiguration(BaseModel):  # pylint: disable=too-few-public-method
     :param authorization_claim: Claim to use for extracting authorization scopes.
         Defaults to ``roles``.
     :type authorization_claim: str, optional
+    :param authorization_claim_path: The path to the Claim to use for authorization. To use if the authorization Claim is nested in the payload.
+        Defaults to ``[]``.
+    :type authorization_claim_path: list[str], optional
     :param use_introspection_endpoint: Whether to use the introspection endpoint
         for token validation. Should not be needed for Keycloak in general
         as Keycloak doesn't support opaque tokens. Defaults to ``False``.
@@ -101,6 +104,11 @@ class KeycloakConfiguration(BaseModel):  # pylint: disable=too-few-public-method
         "roles",
         title="Authorization Claim",
         description="The claim to use for authorization.",
+    )
+    authorization_claim_path: list[str] = Field(
+        [],
+        title="Path to the Authorization Claim",
+        description="The path to the claim to use for authorization. To use if the Authorization Claim is nested in the payload.",
     )
     use_introspection_endpoint: bool = Field(
         False,


### PR DESCRIPTION
I want to use your package to verify requests against a keycloak server.
The problem is that our authorization claims are nested in the payload and couldn't be extracted by the package.

I added the functionality to set a custom path for the **authorization_claim** using a new **authorization_claim_path** parameter.