### PR TITLE
remove unused "install" package from pyproject.toml and poetry.lock requirements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -322,17 +322,6 @@ files = [
 ]
 
 [[package]]
-name = "install"
-version = "1.3.5"
-description = "Install packages from within code"
-optional = false
-python-versions = ">=2.7, >=3.5"
-files = [
-    {file = "install-1.3.5-py3-none-any.whl", hash = "sha256:0d3fadf4aa62c95efe8d34757c8507eb46177f86c016c21c6551eafc6a53d5a9"},
-    {file = "install-1.3.5.tar.gz", hash = "sha256:e67c8a0be5ccf8cb4ffa17d090f3a61b6e820e6a7e21cd1d2c0f7bc59b18e647"},
-]
-
-[[package]]
 name = "jinja2"
 version = "3.1.3"
 description = "A very fast and expressive template engine."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ packages = [{ include = "fastapi_keycloak_middleware" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 fastapi = ">=0.73.0"
-install = "^1.3.5"
 python-keycloak = ">2.14.0,<3.9.1"
 ruff = "^0.4.2"
 


### PR DESCRIPTION
Your project defines the "install" package (https://pypi.org/project/install/) as a requirement, but it's not using it's functionality. This pull request removes the dependency.

There's an open discussion to remove the "install" package from pypi.org: https://github.com/pypi/support/issues/451

Since your project does not depend on the "install" package functionality, the requirement should be removed to avoid install problems, if the "install" package get removed from pypi.org.