### PR TITLE
updated base path in docs for newer keycloak versions

### DIFF
--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -49,7 +49,7 @@ If you want to still use the token endpoint to validate the token, you can opt t
 
     # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",
@@ -69,7 +69,7 @@ all security features of the library.
 
     # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",
@@ -218,7 +218,7 @@ The following example shows the configurtion on the library side:
 
     # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",

--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -45,7 +45,7 @@ To enable authorization, simply pass the chosen method to the middleware initial
 
     # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,7 +15,7 @@ This is a very basic example on how to add the Middleware to a FastAPI applicati
 
    # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",
@@ -145,7 +145,7 @@ The authentication scheme is essentially the prefix of the :code:`Authorization`
 
     # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",
@@ -260,7 +260,7 @@ You can also configure the class to extract other / additional claims from the t
 
     # Set up Keycloak
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",
@@ -283,7 +283,7 @@ separate client is then configured using the :code:`swagger_client_id`  paramete
    :emphasize-lines: 6,7,8,9,15
 
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",
@@ -320,7 +320,7 @@ attribute, which must be the True or False bool or the str path to the CA bundle
 
     # Set up Keycloak connection
     keycloak_config = KeycloakConfiguration(
-        url="https://sso.your-keycloak.com/auth/",
+        url="https://sso.your-keycloak.com",
         realm="<Realm Name>",
         client_id="<Client ID>",
         client_secret="<Client Secret>",


### PR DESCRIPTION
Current example causes errors.
the /auth endpoint was removed in keycloak 17+
The base path is now simply /
https://forum.keycloak.org/t/changes-in-oidc-token-endpoints/18024
https://github.com/keycloak/keycloak/issues/10464