### PR TITLE
fix: Avoid duplicate slashes in Swagger auth OIDC path

### DIFF
--- a/fastapi_keycloak_middleware/setup.py
+++ b/fastapi_keycloak_middleware/setup.py
@@ -137,7 +137,7 @@ def setup_keycloak_middleware(  # pylint: disable=too-many-arguments
         suffix = ".well-known/openid-configuration"
         openId_base_url = swagger_openId_base_url or keycloak_configuration.url
         security_scheme = OpenIdConnect(
-            openIdConnectUrl=f"{openId_base_url}/realms/{keycloak_configuration.realm}/{suffix}",
+            openIdConnectUrl=f"{openId_base_url.rstrip('/')}/realms/{keycloak_configuration.realm}/{suffix}",
             scheme_name=swagger_scheme_name,
             auto_error=False,
         )


### PR DESCRIPTION
When using legacy Keycloak versions with auth context (e.g. `https://keycloak.example.com/auth/`), the trailing slash is required for the Keycloak configuration URL. Using the Swagger auth feature, this will result in a double slash in the URL path:

```
https://keycloak.example.com/auth//realms/<realm>/.well-known/openid-configuration
```

